### PR TITLE
feat: BaseTimeEntity, JpaAuditingConfig 추가

### DIFF
--- a/src/main/java/com/peelie/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/peelie/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.peelie.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/peelie/common/jpa/BaseTimeEntity.java
+++ b/src/main/java/com/peelie/common/jpa/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.peelie.common.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
# Pull Request

**공통 엔티티 시간 관리 위한 BaseTimeEntity 추가 및 JPA Auditing 설정 적용**

## #️⃣ 연관된 이슈

#5 

## 작업 내용

•	BaseTimeEntity 추상 클래스 추가
	•	createdAt, updatedAt 필드 자동 관리 (@CreatedDate, @LastModifiedDate 적용)
•	JpaAuditingConfig 생성
	•	@EnableJpaAuditing 활성화로 Auditing 기능 동작 보장

