### PR TITLE
Feature/9 대체키외부 식별자 토큰 발급 클래스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
+    implementation 'org.apache.commons:commons-text:1.14.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/peelie/common/util/TokenGenerator.java
+++ b/src/main/java/com/peelie/common/util/TokenGenerator.java
@@ -1,0 +1,21 @@
+package com.peelie.common.util;
+
+import org.apache.commons.text.CharacterPredicates;
+import org.apache.commons.text.RandomStringGenerator;
+
+public class TokenGenerator {
+    private static final int TOKEN_LENGTH = 20;
+
+    private static final RandomStringGenerator alphanumericGenerator = new RandomStringGenerator.Builder()
+            .withinRange('0', 'z')
+            .filteredBy(CharacterPredicates.LETTERS, CharacterPredicates.DIGITS)
+            .get();
+
+    public static String randomCharacter(int length) {
+        return alphanumericGenerator.generate(length);
+    }
+
+    public static String randomCharacterWithPrefix(String prefix) {
+        return prefix + randomCharacter(TOKEN_LENGTH - prefix.length());
+    }
+}


### PR DESCRIPTION
# Pull Request

**대체키 토큰 생성 유틸 추가**

## #️⃣ 연관된 이슈

#9 

## 작업 내용
- Apache Commons 라이브러리 추가 (commons-lang3, commons-text)
- TokenGenerator 유틸 구현 (20자리 영문+숫자 토큰 생성, prefix 지원)
