### PR TITLE
chore(common): 응답 형식 변경 - null 값인 필드도 응답에 포함

### DIFF
--- a/src/main/java/com/peelie/common/response/ErrorResponse.java
+++ b/src/main/java/com/peelie/common/response/ErrorResponse.java
@@ -1,13 +1,11 @@
 package com.peelie.common.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.peelie.common.exception.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
 
     private final int status;

--- a/src/main/java/com/peelie/common/response/SuccessResponse.java
+++ b/src/main/java/com/peelie/common/response/SuccessResponse.java
@@ -1,13 +1,11 @@
 package com.peelie.common.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SuccessResponse<T> {
 
     private final int status;


### PR DESCRIPTION
# Pull Request

**1. 응답 형식 변경 - null 값인 필드도 응답에 포함
2. SuccessResponse, ErrorResponse에서 @JsonInclude(JsonInclude.Include.NON_NULL) 어노테이션 제거.**

## #️⃣ 연관된 이슈

#4 

## 작업 내용

- common의 응답 클래스에서 @JsonInclude(JsonInclude.Include.NON_NULL) 어노테이션 제거.
