### PR TITLE
chore(auth): 로그인 응답값 수정 - 중복의미를 가지는 필드 삭제

### DIFF
--- a/src/main/java/com/peelie/auth/application/LoginResponse.java
+++ b/src/main/java/com/peelie/auth/application/LoginResponse.java
@@ -5,12 +5,10 @@ import lombok.Getter;
 @Getter
 public class LoginResponse {
     private final String jwt;      // jwt 토큰 (신규 유저일 경우 임시 토큰, 기존 유저일 경우 최종 토큰)
-    private final String jwtType;  // jwt 토큰 타입 ("pending" or "completed")
     private final boolean isNewUser; // 신규 유저 여부
 
-    public LoginResponse(String jwt, String jwtType, boolean isNewUser) {
+    public LoginResponse(String jwt, boolean isNewUser) {
         this.jwt = jwt;
-        this.jwtType = jwtType;
         this.isNewUser = isNewUser;
     }
 }

--- a/src/main/java/com/peelie/auth/application/OauthFacade.java
+++ b/src/main/java/com/peelie/auth/application/OauthFacade.java
@@ -22,11 +22,11 @@ public class OauthFacade {
         if (isLinked) {
             // 기존 유저: 정상 엑세스 토큰 발급
             String completedJwt = jwtUtil.createCompletedJwt(oauthInfo.getUserId());
-            return new LoginResponse(completedJwt, "completed", false);
+            return new LoginResponse(completedJwt, false);
         } else {
             //신규 유저: 임시 토큰 발급
             String pendingJwt = jwtUtil.createPendingJwt(oauthInfo.getId());
-            return new LoginResponse(pendingJwt, "pending", true);
+            return new LoginResponse(pendingJwt, true);
         }
     }
 }


### PR DESCRIPTION
# Pull Request

**[작업 내용을 간략히 적어주세요]**
```
- 로그인 api 응답값에서 jwtType과 newUser가 중복의미를 가짐
- jwtType필드 삭제
```

## #️⃣ 연관된 이슈

#18 

## 작업 내용

LoginResponse: jwtType필드 및 생성자 수정
OauthFacade: 리턴 하는 라인에서 jwtType부분 응답하지 않도록 수정
