### PR TITLE
Feature/17 questionnaire 도메인 필수 기능 구현

### DIFF
--- a/src/main/java/com/peelie/questionnaire/application/QuestionnaireAppService.java
+++ b/src/main/java/com/peelie/questionnaire/application/QuestionnaireAppService.java
@@ -11,7 +11,7 @@ public class QuestionnaireAppService {
 
     private final CategoryService categoryService;
 
-    public CategoryInfo.Main retrieveCategory(Long id) {
-        return categoryService.getCategory(id);
+    public CategoryInfo.Main retrieveCategory(String categoryName) {
+        return categoryService.getCategoryByName(categoryName);
     }
 }

--- a/src/main/java/com/peelie/questionnaire/application/QuestionnaireAppService.java
+++ b/src/main/java/com/peelie/questionnaire/application/QuestionnaireAppService.java
@@ -1,0 +1,17 @@
+package com.peelie.questionnaire.application;
+
+import com.peelie.questionnaire.domain.CategoryInfo;
+import com.peelie.questionnaire.domain.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionnaireAppService {
+
+    private final CategoryService categoryService;
+
+    public CategoryInfo.Main retrieveCategory(Long id) {
+        return categoryService.getCategory(id);
+    }
+}

--- a/src/main/java/com/peelie/questionnaire/domain/Category.java
+++ b/src/main/java/com/peelie/questionnaire/domain/Category.java
@@ -22,6 +22,7 @@ public class Category extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String categoryName;
 
     // L0 ~ L3 객관식 질문들

--- a/src/main/java/com/peelie/questionnaire/domain/Category.java
+++ b/src/main/java/com/peelie/questionnaire/domain/Category.java
@@ -36,8 +36,8 @@ public class Category extends BaseTimeEntity {
     }
 
     public void addChoiceQuestion(ChoiceQuestion question) {
-        if (choiceQuestions.size() != 4) { // L0~L3
-            throw new BaseException("객관식 질문은 4개를 등록 해야합니다.", ErrorCode.VALIDATION_ERROR);
+        if (choiceQuestions.size() >= 4) { // L0~L3
+            throw new BaseException("객관식 질문은 4개까지 등록 가능합니다.", ErrorCode.VALIDATION_ERROR);
         }
         this.choiceQuestions.add(question);
     }

--- a/src/main/java/com/peelie/questionnaire/domain/Category.java
+++ b/src/main/java/com/peelie/questionnaire/domain/Category.java
@@ -1,0 +1,48 @@
+package com.peelie.questionnaire.domain;
+
+import com.peelie.common.exception.BaseException;
+import com.peelie.common.exception.ErrorCode;
+import com.peelie.common.jpa.BaseTimeEntity;
+import com.peelie.questionnaire.domain.question.ChoiceQuestion;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "onboarding_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String categoryName;
+
+    // L0 ~ L3 객관식 질문들
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChoiceQuestion> choiceQuestions = new ArrayList<>();
+
+    // L4 서술형 질문
+    private String l4Question;
+
+    public Category(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public void addChoiceQuestion(ChoiceQuestion question) {
+        if (choiceQuestions.size() != 4) { // L0~L3
+            throw new BaseException("객관식 질문은 4개를 등록 해야합니다.", ErrorCode.VALIDATION_ERROR);
+        }
+        this.choiceQuestions.add(question);
+    }
+
+    public void updateL4Question(String l4Question) {
+        this.l4Question = l4Question;
+    }
+}

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryCommand.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryCommand.java
@@ -1,0 +1,37 @@
+package com.peelie.questionnaire.domain;
+
+import com.peelie.questionnaire.domain.question.QuestionLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+public class CategoryCommand {
+
+    @Getter
+    @Builder
+    @ToString
+    public static class RegisterCategory {
+        private String categoryName;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class RegisterQuestion {
+        private QuestionLevel level; // L0, L1, L2, L3, L4
+        private String content;
+        private List<String> options; // L0~L3 객관식 질문에만 사용, L4는 null
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class UpdateQuestion {
+        private Long questionId;
+        private QuestionLevel level;
+        private String content;
+        private List<String> options;
+    }
+}

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryInfo.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryInfo.java
@@ -4,7 +4,9 @@ import com.peelie.questionnaire.domain.question.ChoiceQuestion;
 import com.peelie.questionnaire.domain.question.QuestionLevel;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CategoryInfo {
 
@@ -20,8 +22,8 @@ public class CategoryInfo {
 
             List<QuestionInfo> questionInfoList = category.getChoiceQuestions().stream()
                     .map(QuestionInfo::new)
-                    .toList();
-            questionInfoList.add(new QuestionInfo(category.getL4Question()));
+                    .collect(Collectors.toCollection(ArrayList::new));
+            questionInfoList.add(new QuestionInfo(category.getL4Question())); // 이 부분 수정
 
             this.questions = questionInfoList;
         }
@@ -41,10 +43,10 @@ public class CategoryInfo {
             this.options = question.getOptions();
         }
 
-        public QuestionInfo(String l4Content) {
+        public QuestionInfo(String l4Question) {
             this.level = QuestionLevel.L4;
             this.type = "TEXT";
-            this.content = l4Content;
+            this.content = l4Question;
             this.options = null;
         }
     }

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryInfo.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryInfo.java
@@ -1,0 +1,51 @@
+package com.peelie.questionnaire.domain;
+
+import com.peelie.questionnaire.domain.question.ChoiceQuestion;
+import com.peelie.questionnaire.domain.question.QuestionLevel;
+import lombok.Getter;
+
+import java.util.List;
+
+public class CategoryInfo {
+
+    @Getter
+    public static class Main {
+        private final Long categoryId;
+        private final String categoryName;
+        private final List<QuestionInfo> questions;
+
+        public Main(Category category) {
+            this.categoryId = category.getId();
+            this.categoryName = category.getCategoryName();
+
+            List<QuestionInfo> questionInfoList = category.getChoiceQuestions().stream()
+                    .map(QuestionInfo::new)
+                    .toList();
+            questionInfoList.add(new QuestionInfo(category.getL4Question()));
+
+            this.questions = questionInfoList;
+        }
+    }
+
+    @Getter
+    public static class QuestionInfo {
+        private final QuestionLevel level;
+        private final String type;
+        private final String content;
+        private final List<String> options;
+
+        public QuestionInfo(ChoiceQuestion question) {
+            this.level = question.getLevel();
+            this.type = "CHOICE";
+            this.content = question.getContent();
+            this.options = question.getOptions();
+        }
+
+        public QuestionInfo(String l4Content) {
+            this.level = QuestionLevel.L4;
+            this.type = "TEXT";
+            this.content = l4Content;
+            this.options = null;
+        }
+    }
+}

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryReader.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryReader.java
@@ -1,0 +1,9 @@
+package com.peelie.questionnaire.domain;
+
+
+import java.util.List;
+
+public interface CategoryReader {
+    Category getCategory(Long id);
+    List<Category> getAllCategories();
+}

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryReader.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryReader.java
@@ -5,5 +5,6 @@ import java.util.List;
 
 public interface CategoryReader {
     Category getCategory(Long id);
+    Category getCategoryByName(String categoryName);
     List<Category> getAllCategories();
 }

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryService.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryService.java
@@ -7,5 +7,6 @@ public interface CategoryService {
     CategoryInfo.Main registerCategory(CategoryCommand.RegisterCategory command);
     List<CategoryInfo.Main> getAllCategories();
     CategoryInfo.Main getCategory(Long categoryId);
+    CategoryInfo.Main getCategoryByName(String categoryName);
     CategoryInfo.Main registerQuestion(Long categoryId, CategoryCommand.RegisterQuestion command);
 }

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryService.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryService.java
@@ -1,0 +1,11 @@
+package com.peelie.questionnaire.domain;
+
+import java.util.List;
+
+public interface CategoryService {
+
+    CategoryInfo.Main registerCategory(CategoryCommand.RegisterCategory command);
+    List<CategoryInfo.Main> getAllCategories();
+    CategoryInfo.Main getCategory(Long categoryId);
+    CategoryInfo.Main registerQuestion(Long categoryId, CategoryCommand.RegisterQuestion command);
+}

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryServiceImpl.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryServiceImpl.java
@@ -42,6 +42,12 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
+    public CategoryInfo.Main getCategoryByName(String categoryName) {
+        Category category = categoryReader.getCategoryByName(categoryName);
+        return new CategoryInfo.Main(category);
+    }
+
+    @Override
     @Transactional
     public CategoryInfo.Main registerQuestion(Long categoryId, CategoryCommand.RegisterQuestion command) {
         Category category = categoryReader.getCategory(categoryId);

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryServiceImpl.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryServiceImpl.java
@@ -1,0 +1,79 @@
+package com.peelie.questionnaire.domain;
+
+import com.peelie.common.exception.BaseException;
+import com.peelie.common.exception.ErrorCode;
+import com.peelie.questionnaire.domain.question.ChoiceQuestion;
+import com.peelie.questionnaire.domain.question.QuestionLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryReader categoryReader;
+    private final CategoryStore categoryStore;
+
+    @Override
+    @Transactional
+    public CategoryInfo.Main registerCategory(CategoryCommand.RegisterCategory command) {
+        Category newCategory = new Category(command.getCategoryName());
+        Category savedCategory = categoryStore.store(newCategory);
+        return new CategoryInfo.Main(savedCategory);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CategoryInfo.Main> getAllCategories() {
+        List<Category> categories = categoryReader.getAllCategories();
+        return categories.stream()
+                .map(CategoryInfo.Main::new)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CategoryInfo.Main getCategory(Long categoryId) {
+        Category category = categoryReader.getCategory(categoryId);
+        return new CategoryInfo.Main(category);
+    }
+
+    @Override
+    @Transactional
+    public CategoryInfo.Main registerQuestion(Long categoryId, CategoryCommand.RegisterQuestion command) {
+        Category category = categoryReader.getCategory(categoryId);
+
+        if (command.getLevel() == QuestionLevel.L4) {
+            if (category.getL4Question() != null) {
+                throw new BaseException("L4 질문은 이미 등록되어 있습니다.", ErrorCode.VALIDATION_ERROR);
+            }
+            if (command.getOptions() != null && !command.getOptions().isEmpty()) {
+                throw new BaseException("L4 질문에는 선택지를 등록할 수 없습니다.", ErrorCode.VALIDATION_ERROR);
+            }
+            category.updateL4Question(command.getContent());
+        } else {
+            // L0~L3 객관식 질문 등록
+            if (category.getChoiceQuestions().stream()
+                    .anyMatch(q -> q.getLevel() == command.getLevel())) {
+                throw new BaseException(command.getLevel() + " 레벨의 객관식 질문은 이미 등록되어 있습니다.", ErrorCode.VALIDATION_ERROR);
+            }
+            if (command.getOptions() == null || command.getOptions().size() != 4) {
+                throw new BaseException("객관식 질문은 4개의 선택지를 가져야 합니다.", ErrorCode.VALIDATION_ERROR);
+            }
+
+            ChoiceQuestion newChoiceQuestion = ChoiceQuestion.builder()
+                    .category(category)
+                    .level(command.getLevel())
+                    .content(command.getContent())
+                    .options(command.getOptions())
+                    .build();
+
+            category.addChoiceQuestion(newChoiceQuestion);
+        }
+        Category savedCategory = categoryStore.store(category);
+        return new CategoryInfo.Main(savedCategory);
+    }
+}

--- a/src/main/java/com/peelie/questionnaire/domain/CategoryStore.java
+++ b/src/main/java/com/peelie/questionnaire/domain/CategoryStore.java
@@ -1,0 +1,5 @@
+package com.peelie.questionnaire.domain;
+
+public interface CategoryStore {
+    Category store(Category category);
+}

--- a/src/main/java/com/peelie/questionnaire/domain/question/ChoiceQuestion.java
+++ b/src/main/java/com/peelie/questionnaire/domain/question/ChoiceQuestion.java
@@ -1,5 +1,7 @@
 package com.peelie.questionnaire.domain.question;
 
+import com.peelie.common.exception.BaseException;
+import com.peelie.common.exception.ErrorCode;
 import com.peelie.common.jpa.BaseTimeEntity;
 import com.peelie.questionnaire.domain.Category;
 import jakarta.persistence.*;
@@ -34,6 +36,7 @@ public class ChoiceQuestion extends BaseTimeEntity {
 
     @ElementCollection
     @CollectionTable(name = "question_options", joinColumns = @JoinColumn(name = "question_id"))
+    @OrderColumn(name = "option_idx")
     @Column(name = "option_content")
     private List<String> options = new ArrayList<>();
 
@@ -47,10 +50,10 @@ public class ChoiceQuestion extends BaseTimeEntity {
 
     public void update(String content, List<String> options) {
         if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("질문내용을 입력해주세요");
+            throw new BaseException("질문내용을 입력해주세요", ErrorCode.VALIDATION_ERROR);
         }
         if (options == null || options.size() != 4) {
-            throw new IllegalArgumentException("객관식 질문은 4개여야합니다");
+            throw new BaseException("객관식 선택지는 4개이어야합니다", ErrorCode.VALIDATION_ERROR);
         }
         this.content = content;
         this.options = options;

--- a/src/main/java/com/peelie/questionnaire/domain/question/ChoiceQuestion.java
+++ b/src/main/java/com/peelie/questionnaire/domain/question/ChoiceQuestion.java
@@ -1,0 +1,58 @@
+package com.peelie.questionnaire.domain.question;
+
+import com.peelie.common.jpa.BaseTimeEntity;
+import com.peelie.questionnaire.domain.Category;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "choice_questions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChoiceQuestion extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "level", nullable = false)
+    private QuestionLevel level;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ElementCollection
+    @CollectionTable(name = "question_options", joinColumns = @JoinColumn(name = "question_id"))
+    @Column(name = "option_content")
+    private List<String> options = new ArrayList<>();
+
+    @Builder
+    public ChoiceQuestion(Category category, QuestionLevel level, String content, List<String> options) {
+        this.category = category;
+        this.level = level;
+        this.content = content;
+        this.options = options;
+    }
+
+    public void update(String content, List<String> options) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("질문내용을 입력해주세요");
+        }
+        if (options == null || options.size() != 4) {
+            throw new IllegalArgumentException("객관식 질문은 4개여야합니다");
+        }
+        this.content = content;
+        this.options = options;
+    }
+}

--- a/src/main/java/com/peelie/questionnaire/domain/question/QuestionLevel.java
+++ b/src/main/java/com/peelie/questionnaire/domain/question/QuestionLevel.java
@@ -1,0 +1,5 @@
+package com.peelie.questionnaire.domain.question;
+
+public enum QuestionLevel {
+    L0, L1, L2, L3, L4
+}

--- a/src/main/java/com/peelie/questionnaire/infra/CategoryReaderImpl.java
+++ b/src/main/java/com/peelie/questionnaire/infra/CategoryReaderImpl.java
@@ -1,0 +1,28 @@
+package com.peelie.questionnaire.infra;
+
+import com.peelie.common.exception.BaseException;
+import com.peelie.common.exception.ErrorCode;
+import com.peelie.questionnaire.domain.Category;
+import com.peelie.questionnaire.domain.CategoryReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryReaderImpl implements CategoryReader {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Category getCategory(Long id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new BaseException("카테고리가 존재하지 않습니다", ErrorCode.NOT_FOUND));
+    }
+
+    @Override
+    public List<Category> getAllCategories() {
+        return categoryRepository.findAll();
+    }
+}

--- a/src/main/java/com/peelie/questionnaire/infra/CategoryReaderImpl.java
+++ b/src/main/java/com/peelie/questionnaire/infra/CategoryReaderImpl.java
@@ -22,6 +22,12 @@ public class CategoryReaderImpl implements CategoryReader {
     }
 
     @Override
+    public Category getCategoryByName(String categoryName) {
+        return categoryRepository.findByCategoryName(categoryName)
+                .orElseThrow(() -> new BaseException(categoryName +  "해당 이름의 카테고리가 존재하지 않습니다.", ErrorCode.NOT_FOUND));
+    }
+
+    @Override
     public List<Category> getAllCategories() {
         return categoryRepository.findAll();
     }

--- a/src/main/java/com/peelie/questionnaire/infra/CategoryRepository.java
+++ b/src/main/java/com/peelie/questionnaire/infra/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.peelie.questionnaire.infra;
+
+import com.peelie.questionnaire.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/peelie/questionnaire/infra/CategoryRepository.java
+++ b/src/main/java/com/peelie/questionnaire/infra/CategoryRepository.java
@@ -3,5 +3,8 @@ package com.peelie.questionnaire.infra;
 import com.peelie.questionnaire.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByCategoryName(String categoryName);
 }

--- a/src/main/java/com/peelie/questionnaire/infra/CategoryStoreImpl.java
+++ b/src/main/java/com/peelie/questionnaire/infra/CategoryStoreImpl.java
@@ -1,0 +1,19 @@
+package com.peelie.questionnaire.infra;
+
+
+import com.peelie.questionnaire.domain.Category;
+import com.peelie.questionnaire.domain.CategoryStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryStoreImpl implements CategoryStore{
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Category store(Category category) {
+        return categoryRepository.save(category);
+    }
+}

--- a/src/main/java/com/peelie/questionnaire/interfaces/QuestionnaireController.java
+++ b/src/main/java/com/peelie/questionnaire/interfaces/QuestionnaireController.java
@@ -1,0 +1,24 @@
+package com.peelie.questionnaire.interfaces;
+
+import com.peelie.common.response.SuccessResponse;
+import com.peelie.questionnaire.application.QuestionnaireAppService;
+import com.peelie.questionnaire.domain.CategoryInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/questionnaire")
+@RequiredArgsConstructor
+public class QuestionnaireController {
+
+    private final QuestionnaireAppService questionnaireAppService;
+
+    @GetMapping
+    public SuccessResponse getCategory(@RequestParam("category") String categoryName) {
+        CategoryInfo.Main categoryResult = questionnaireAppService.retrieveCategory(categoryName);
+        return SuccessResponse.ok(categoryResult);
+    }
+}

--- a/src/test/java/com/peelie/questionnaire/domain/CategoryServiceTest.java
+++ b/src/test/java/com/peelie/questionnaire/domain/CategoryServiceTest.java
@@ -1,0 +1,85 @@
+package com.peelie.questionnaire.domain;
+
+import com.peelie.questionnaire.domain.question.ChoiceQuestion;
+import com.peelie.questionnaire.domain.question.QuestionLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class CategoryServiceTest {
+
+    @Autowired
+    CategoryService categoryService;
+
+    @Autowired
+    CategoryStore categoryStore;
+
+    @BeforeEach
+    void setUp() {
+        Category category1 = new Category("테스트 카테고리1");
+
+        for (int i = 0; i < 4; i++) {
+            ChoiceQuestion question = new ChoiceQuestion(
+                    category1,
+                    QuestionLevel.values()[i],
+                    "카테고리 1의 질문 " + i,
+                    new ArrayList<>(List.of("선택지1", "선택지2", "선택지3", "선택지4"))
+            );
+            category1.addChoiceQuestion(question);
+        }
+
+        category1.updateL4Question("카테고리 1의 질문 4");
+
+        Category category2 = new Category("테스트 카테고리2");
+
+        categoryStore.store(category1);
+        categoryStore.store(category2);
+    }
+
+    @Test
+    void 전체조회() {
+        //then
+        assertThat(categoryService.getAllCategories().size()).isEqualTo(2);
+        assertThat(categoryService.getAllCategories().get(0).getQuestions().size()).isEqualTo(5);
+        assertThat(categoryService.getAllCategories().get(1).getQuestions().size()).isEqualTo(1);
+    }
+
+    @Test
+    void 단일조회() {
+        assertThat(categoryService.getCategory(1L).getCategoryName()).isEqualTo("테스트 카테고리1");
+
+        assertThat(categoryService.getCategory(1L).getQuestions().get(0).getContent())
+                .isEqualTo("카테고리 1의 질문 0");
+        assertThat(categoryService.getCategory(1L).getQuestions().get(0).getOptions().size())
+                .isEqualTo(4);
+
+        assertThat(categoryService.getCategory(1L).getQuestions().get(1).getContent())
+                .isEqualTo("카테고리 1의 질문 1");
+        assertThat(categoryService.getCategory(1L).getQuestions().get(1).getOptions().size())
+                .isEqualTo(4);
+
+        assertThat(categoryService.getCategory(1L).getQuestions().get(2).getContent())
+                .isEqualTo("카테고리 1의 질문 2");
+        assertThat(categoryService.getCategory(1L).getQuestions().get(2).getOptions().size())
+                .isEqualTo(4);
+
+        assertThat(categoryService.getCategory(1L).getQuestions().get(3).getContent())
+                .isEqualTo("카테고리 1의 질문 3");
+        assertThat(categoryService.getCategory(1L).getQuestions().get(3).getOptions().size())
+                .isEqualTo(4);
+
+        assertThat(categoryService.getCategory(1L).getQuestions().getLast().getContent())
+                .isEqualTo("카테고리 1의 질문 4");
+
+        assertThat(categoryService.getCategory(2L).getCategoryName()).isEqualTo("테스트 카테고리2");
+    }
+}

--- a/src/test/java/com/peelie/questionnaire/domain/CategoryServiceTest.java
+++ b/src/test/java/com/peelie/questionnaire/domain/CategoryServiceTest.java
@@ -23,9 +23,12 @@ class CategoryServiceTest {
     @Autowired
     CategoryStore categoryStore;
 
+    Category category1;
+    Category category2;
+
     @BeforeEach
     void setUp() {
-        Category category1 = new Category("테스트 카테고리1");
+        category1 = new Category("테스트 카테고리1");
 
         for (int i = 0; i < 4; i++) {
             ChoiceQuestion question = new ChoiceQuestion(
@@ -39,7 +42,7 @@ class CategoryServiceTest {
 
         category1.updateL4Question("카테고리 1의 질문 4");
 
-        Category category2 = new Category("테스트 카테고리2");
+        category2 = new Category("테스트 카테고리2");
 
         categoryStore.store(category1);
         categoryStore.store(category2);
@@ -54,32 +57,43 @@ class CategoryServiceTest {
     }
 
     @Test
-    void 단일조회() {
-        assertThat(categoryService.getCategory(1L).getCategoryName()).isEqualTo("테스트 카테고리1");
+    void 단일조회_id조회() {
 
-        assertThat(categoryService.getCategory(1L).getQuestions().get(0).getContent())
+        Long category1Id = category1.getId();
+        Long category2Id = category2.getId();
+
+        assertThat(categoryService.getCategory(category1Id).getCategoryName()).isEqualTo("테스트 카테고리1");
+
+        assertThat(categoryService.getCategory(category1Id).getQuestions().get(0).getContent())
                 .isEqualTo("카테고리 1의 질문 0");
-        assertThat(categoryService.getCategory(1L).getQuestions().get(0).getOptions().size())
+        assertThat(categoryService.getCategory(category1Id).getQuestions().get(0).getOptions().size())
                 .isEqualTo(4);
 
-        assertThat(categoryService.getCategory(1L).getQuestions().get(1).getContent())
+        assertThat(categoryService.getCategory(category1Id).getQuestions().get(1).getContent())
                 .isEqualTo("카테고리 1의 질문 1");
-        assertThat(categoryService.getCategory(1L).getQuestions().get(1).getOptions().size())
+        assertThat(categoryService.getCategory(category1Id).getQuestions().get(1).getOptions().size())
                 .isEqualTo(4);
 
-        assertThat(categoryService.getCategory(1L).getQuestions().get(2).getContent())
+        assertThat(categoryService.getCategory(category1Id).getQuestions().get(2).getContent())
                 .isEqualTo("카테고리 1의 질문 2");
-        assertThat(categoryService.getCategory(1L).getQuestions().get(2).getOptions().size())
+        assertThat(categoryService.getCategory(category1Id).getQuestions().get(2).getOptions().size())
                 .isEqualTo(4);
 
-        assertThat(categoryService.getCategory(1L).getQuestions().get(3).getContent())
+        assertThat(categoryService.getCategory(category1Id).getQuestions().get(3).getContent())
                 .isEqualTo("카테고리 1의 질문 3");
-        assertThat(categoryService.getCategory(1L).getQuestions().get(3).getOptions().size())
+        assertThat(categoryService.getCategory(category1Id).getQuestions().get(3).getOptions().size())
                 .isEqualTo(4);
 
-        assertThat(categoryService.getCategory(1L).getQuestions().getLast().getContent())
+        assertThat(categoryService.getCategory(category1Id).getQuestions().getLast().getContent())
                 .isEqualTo("카테고리 1의 질문 4");
 
-        assertThat(categoryService.getCategory(2L).getCategoryName()).isEqualTo("테스트 카테고리2");
+        assertThat(categoryService.getCategory(category2Id).getCategoryName()).isEqualTo("테스트 카테고리2");
+    }
+
+    @Test
+    void 단일조회_이름으로조회() {
+        Long category1Id = category1.getId();
+        assertThat(categoryService.getCategoryByName("테스트 카테고리1").getCategoryId())
+                .isEqualTo(category1Id);
     }
 }

--- a/src/test/java/com/peelie/questionnaire/domain/CategoryTest.java
+++ b/src/test/java/com/peelie/questionnaire/domain/CategoryTest.java
@@ -1,0 +1,106 @@
+package com.peelie.questionnaire.domain;
+
+import com.peelie.common.exception.BaseException;
+import com.peelie.questionnaire.domain.question.ChoiceQuestion;
+import com.peelie.questionnaire.domain.question.QuestionLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class CategoryTest {
+
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        category = new Category("테스트 카테고리");
+    }
+
+    @Test
+    void addChoiceQuestion() {
+        // given
+        ChoiceQuestion question = new ChoiceQuestion(
+                category,
+                QuestionLevel.L0,
+                "L0 질문",
+                new ArrayList<>(List.of("1", "2", "3", "4"))
+        );
+
+        // when
+        category.addChoiceQuestion(question);
+
+        // then
+        assertThat(category.getChoiceQuestions()).hasSize(1);
+        assertThat(category.getChoiceQuestions().get(0).getContent()).isEqualTo("L0 질문");
+    }
+
+    @Test
+    void addChoiceQuestion_4개이상등록시예외() {
+        // given
+        for (int i = 0; i < 4; i++) {
+            ChoiceQuestion question = new ChoiceQuestion(
+                    category,
+                    QuestionLevel.values()[i],
+                    "질문 " + i,
+                    new ArrayList<>(List.of("1", "2", "3", "4"))
+            );
+            category.addChoiceQuestion(question);
+        }
+
+        ChoiceQuestion extra = new ChoiceQuestion(
+                category,
+                QuestionLevel.L3,
+                "추가 질문",
+                new ArrayList<>(List.of("1", "2", "3", "4"))
+        );
+
+        // when // then
+        assertThatThrownBy(() -> category.addChoiceQuestion(extra))
+                .isInstanceOf(BaseException.class)
+                .hasMessage("객관식 질문은 4개까지 등록 가능합니다.");
+    }
+
+    @Test
+    void updateL4Question() {
+        // given
+        String l4 = "서술형 질문입니다";
+
+        // when
+        category.updateL4Question(l4);
+
+        // then
+        assertThat(category.getL4Question()).isEqualTo(l4);
+    }
+
+    @Test
+    void getCategoryName() {
+        // when
+        String name = category.getCategoryName();
+
+        // then
+        assertThat(name).isEqualTo("테스트 카테고리");
+    }
+
+    @Test
+    void 출력_테스트() {
+        System.out.println(category);
+
+        for (int i = 0; i < 4; i++) {
+            ChoiceQuestion question = new ChoiceQuestion(
+                    category,
+                    QuestionLevel.values()[i],
+                    "질문 " + i,
+                    new ArrayList<>(List.of("선택지1", "2", "3", "4"))
+            );
+            category.addChoiceQuestion(question);
+        }
+        category.updateL4Question("질문 4");
+
+        CategoryInfo.Main main = new CategoryInfo.Main(category);
+        System.out.println(main.getQuestions());
+    }
+}


### PR DESCRIPTION
# Pull Request

**- 온보딩 설문에서 받을 질문 템플릿 관련 기능 구현**
- _관리자기능이 없기 때문에 따로 API로 구현은 하지 않을 예정_**(9/30 질문 조회 API추가 하는 걸로 변경)**
**- 다른 도메인에서 주로 조회용 서비스 코드 호출하는 방식으로 활용할 예정**

## #️⃣ 연관된 이슈

#17 

## 작업 내용

- L4 서술형 질문은 일단 따로 필드로 빼서 String으로 저장해두었습니다.

**DB 저장 형식 참고**
**onboarding_category - 카테고리 테이블**
<img width="865" height="51" alt="image" src="https://github.com/user-attachments/assets/1dd9a562-1d13-4b1f-86be-d697891780a7" />
**choice_questions - 카테고리별로 저장될 질문 테이블**
<img width="988" height="117" alt="image" src="https://github.com/user-attachments/assets/39168501-ff14-4424-bafa-871c2cde9799" />
**question_options - L0~L3 질문에서 고를 선택지**
<img width="676" height="385" alt="image" src="https://github.com/user-attachments/assets/7b7b99a6-05ad-4ff0-b28d-00d90c23b151" />


