### PR TITLE
chore: questionnaire 도메인 엔티티 @Table에서 테이블이름 prefix 수정

### DIFF
--- a/src/main/java/com/peelie/questionnaire/domain/category/Category.java
+++ b/src/main/java/com/peelie/questionnaire/domain/category/Category.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "onboarding_categories")
+@Table(name = "questionnaire_categories")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category extends BaseTimeEntity {

--- a/src/main/java/com/peelie/questionnaire/domain/category/SubCategory.java
+++ b/src/main/java/com/peelie/questionnaire/domain/category/SubCategory.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "onboarding_subcategories")
+@Table(name = "questionnaire_subcategories")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubCategory extends BaseTimeEntity {

--- a/src/main/java/com/peelie/questionnaire/domain/question/Question.java
+++ b/src/main/java/com/peelie/questionnaire/domain/question/Question.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "onboarding_questions")
+@Table(name = "questionnaire_questions")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question extends BaseTimeEntity {

--- a/src/main/java/com/peelie/questionnaire/domain/question/QuestionOption.java
+++ b/src/main/java/com/peelie/questionnaire/domain/question/QuestionOption.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 @Entity
-@Table(name = "question_options")
+@Table(name = "questionnaire_question_options")
 @Getter
 public class QuestionOption extends BaseTimeEntity {
 


### PR DESCRIPTION
onboarding_ -> questionnaire_

# Pull Request

**questionnaire 도메인 엔티티 @Table에서 테이블이름 prefix 수정**

## #️⃣ 연관된 이슈

#62 

## 작업 내용

이슈 한 번 확인 해주세요
테이블 볼 때 onboarding_으로 이름이 시작해서 온보딩 테이블이랑 혼동이 되어서 questionnaire_으로 시작하도록 수정했습니다
