### PR TITLE
Feature/78 카드bio 비동기 적용 및 프로필에 반영

### DIFF
--- a/src/main/java/com/peelie/onboarding/application/OnboardingFacade.java
+++ b/src/main/java/com/peelie/onboarding/application/OnboardingFacade.java
@@ -4,14 +4,21 @@ import com.peelie.onboarding.domain.GeneratedCardBio;
 import com.peelie.onboarding.domain.OnboardingCommand;
 import com.peelie.onboarding.domain.OnboardingInfo;
 import com.peelie.onboarding.domain.OnboardingProcessService;
+import com.peelie.profile.domain.ProfileCommand;
+import com.peelie.profile.domain.ProfileService;
+import com.peelie.prompt.PromptGenerator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OnboardingFacade {
-    private final OnboardingProcessService onboardingProcessService;
 
+    private final OnboardingProcessService onboardingProcessService;
+    private final ProfileService profileService;
+    private final PromptGenerator promptGenerator;
 
     public OnboardingInfo.Process selectCategories(OnboardingCommand.SelectCategories command) {
         return onboardingProcessService.selectCategories(command);
@@ -22,11 +29,20 @@ public class OnboardingFacade {
     }
 
     public OnboardingInfo.Process submitInteractionStyle(OnboardingCommand.SubmitInteraction command) {
+        profileService.updateInteractionStyle(command.getUserId(), command.getInteractionStyle());
         return onboardingProcessService.submitInteractionStyle(command);
     }
 
-    public GeneratedCardBio generateInitCards(Long userId) {
-        return onboardingProcessService.generateCardBio(userId);
-        // TODO: 여기에서 프로필에 저장하거나, 프로필에서 온보딩 서비스 코드를 호출할 지 추후 결정
+    // TODO: 예외 처리 게선 고민해보기
+    public void generateInitCards(Long userId) {
+        String userPrompt = promptGenerator.generatePrompt(userId);
+        onboardingProcessService.generateCardBio(userPrompt)
+                .thenAccept(generatedBio -> {
+                    ProfileCommand.ApplyOnboardingResult command = GeneratedCardBio.toApplyOnboardingResult(generatedBio);
+                    profileService.applyOnboarding(userId, command);
+                }).exceptionally(ex -> {
+            log.error("AI 생성 중 오류 발생: {}", ex.getMessage());
+            return null;
+        });
     }
 }

--- a/src/main/java/com/peelie/onboarding/domain/GeneratedCardBio.java
+++ b/src/main/java/com/peelie/onboarding/domain/GeneratedCardBio.java
@@ -1,6 +1,8 @@
 package com.peelie.onboarding.domain;
 
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.peelie.profile.domain.Card;
+import com.peelie.profile.domain.ProfileCommand;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -48,5 +50,21 @@ public class GeneratedCardBio {
 
         @JsonPropertyDescription("한줄 소개 내용")
         private String bio;
+    }
+
+    // TODO: 프로필 커맨드를 여기서 참조하는게 맞는지 고민해보고 개선하기.
+    public static ProfileCommand.ApplyOnboardingResult toApplyOnboardingResult(GeneratedCardBio generatedBio) {
+        return ProfileCommand.ApplyOnboardingResult.builder()
+                .stage1Card(toCard(generatedBio.getStage1().getCard()))
+                .stage1Bio(generatedBio.getStage1().getBio().getBio())
+                .stage2Card(toCard(generatedBio.getStage2().getCard()))
+                .stage2Bio(generatedBio.getStage2().getBio().getBio())
+                .stage3Card(toCard(generatedBio.getStage3().getCard()))
+                .stage3Bio(generatedBio.getStage3().getBio().getBio())
+                .build();
+    }
+
+    public static Card toCard(GeneratedCardBio.InitCard initCard) {
+        return new Card(initCard.getTitle(), initCard.getSubTitle(), initCard.getContent());
     }
 }

--- a/src/main/java/com/peelie/onboarding/domain/OnboardingProcessService.java
+++ b/src/main/java/com/peelie/onboarding/domain/OnboardingProcessService.java
@@ -1,12 +1,13 @@
 package com.peelie.onboarding.domain;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface OnboardingProcessService {
-    // OnboardingInfo.Process startOnboarding(Long userId);
     OnboardingInfo.Process selectCategories(OnboardingCommand.SelectCategories command);
 
     OnboardingInfo.Process submitSubCategoryAnswers(OnboardingCommand.SubmitSubCategoryAnswers command);
 
     OnboardingInfo.Process submitInteractionStyle(OnboardingCommand.SubmitInteraction command);
 
-    GeneratedCardBio generateCardBio(Long userId);
+    CompletableFuture<GeneratedCardBio> generateCardBio(String userPrompt);
 }

--- a/src/main/java/com/peelie/onboarding/domain/OnboardingProcessServiceImpl.java
+++ b/src/main/java/com/peelie/onboarding/domain/OnboardingProcessServiceImpl.java
@@ -11,11 +11,13 @@ import com.peelie.questionnaire.domain.question.QuestionInfo;
 import com.peelie.questionnaire.domain.question.QuestionOptionInfo;
 import com.peelie.questionnaire.domain.question.QuestionType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 
 @Service
@@ -137,8 +139,9 @@ public class OnboardingProcessServiceImpl implements OnboardingProcessService {
     }
 
     @Override
-    public GeneratedCardBio generateCardBio(Long userId) {
-        String userPrompt = promptGenerator.generatePrompt(userId);
-        return cardBioGenerator.generate(userPrompt);
+    @Async("asyncExecutor")
+    public CompletableFuture<GeneratedCardBio> generateCardBio(String userPrompt) {
+        GeneratedCardBio generatedResult = cardBioGenerator.generate(userPrompt);
+        return CompletableFuture.completedFuture(generatedResult);
     }
 }

--- a/src/main/java/com/peelie/onboarding/infra/GptCardBioGenerator.java
+++ b/src/main/java/com/peelie/onboarding/infra/GptCardBioGenerator.java
@@ -33,8 +33,6 @@ public class GptCardBioGenerator implements CardBioGenerator {
 
         StructuredResponse<GeneratedCardBio> response = openAIClient.responses().create(params);
 
-        System.out.println("response.toString() = " + response.toString());
-
         return response.output().stream()
                 .flatMap(item -> item.message().stream())
                 .flatMap(message -> message.content().stream())

--- a/src/main/java/com/peelie/onboarding/interfaces/OnboardingController.java
+++ b/src/main/java/com/peelie/onboarding/interfaces/OnboardingController.java
@@ -3,7 +3,6 @@ package com.peelie.onboarding.interfaces;
 import com.peelie.common.context.UserContextHolder;
 import com.peelie.common.response.SuccessResponse;
 import com.peelie.onboarding.application.OnboardingFacade;
-import com.peelie.onboarding.domain.GeneratedCardBio;
 import com.peelie.onboarding.domain.OnboardingCommand;
 import com.peelie.onboarding.domain.OnboardingInfo;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +45,7 @@ public class OnboardingController {
     @GetMapping("/card-bio")
     public SuccessResponse generateInitCards() {
         Long userId = UserContextHolder.getUserId();
-        GeneratedCardBio result = onboardingFacade.generateInitCards(userId);
-        return SuccessResponse.ok(result);
+        onboardingFacade.generateInitCards(userId);
+        return SuccessResponse.ok("카드 및 한줄 소개 생성 중.");
     }
 }

--- a/src/main/java/com/peelie/profile/domain/Card.java
+++ b/src/main/java/com/peelie/profile/domain/Card.java
@@ -1,0 +1,22 @@
+package com.peelie.profile.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Card {
+
+    private String title;
+    private String subtitle;
+    private String content;
+
+    public Card(String title, String subtitle, String content) {
+        this.title = title;
+        this.subtitle = subtitle;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/peelie/profile/domain/Profile.java
+++ b/src/main/java/com/peelie/profile/domain/Profile.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -39,6 +40,31 @@ public class Profile extends BaseTimeEntity {
 
     @Lob
     private String stage3Bio;
+
+    //TODO: 가독성 너무 구려짐.. 나중에 리팩토링 필요
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "title", column = @Column(name = "stage1_title")),
+            @AttributeOverride(name = "subtitle", column = @Column(name = "stage1_subtitle")),
+            @AttributeOverride(name = "content", column = @Column(name = "stage1_content"))
+    })
+    private Card stage1Card;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "title", column = @Column(name = "stage2_title")),
+            @AttributeOverride(name = "subtitle", column = @Column(name = "stage2_subtitle")),
+            @AttributeOverride(name = "content", column = @Column(name = "stage2_content"))
+    })
+    private Card stage2Card;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "title", column = @Column(name = "stage3_title")),
+            @AttributeOverride(name = "subtitle", column = @Column(name = "stage3_subtitle")),
+            @AttributeOverride(name = "content", column = @Column(name = "stage3_content"))
+    })
+    private Card stage3Card;
 
     @Column(unique = true)
     private Long userId;
@@ -102,5 +128,17 @@ public class Profile extends BaseTimeEntity {
 
     public void changeStage3Bio(String newStage3Bio) {
         this.stage3Bio = newStage3Bio;
+    }
+
+    public void setCards(List<Card> cards) {
+        this.stage1Card = cards.get(0);
+        this.stage2Card = cards.get(1);
+        this.stage3Card = cards.get(2);
+    }
+
+    public void setBios(List<String> bios) {
+        this.stage1Bio = bios.get(0);
+        this.stage2Bio = bios.get(1);
+        this.stage3Bio = bios.get(2);
     }
 }

--- a/src/main/java/com/peelie/profile/domain/Profile.java
+++ b/src/main/java/com/peelie/profile/domain/Profile.java
@@ -51,9 +51,6 @@ public class Profile extends BaseTimeEntity {
     @Column(name = "category_id")
     private Set<Long> interestCategoryIds = new HashSet<>();
 
-    @Lob
-    @Column(columnDefinition = "TEXT")
-    private String card;
     @Builder
     public Profile(Long userId, String userName, String profileImageUrl, String instagramId) {
         if (userName == null || userName.isBlank()) {
@@ -106,21 +103,4 @@ public class Profile extends BaseTimeEntity {
     public void changeStage3Bio(String newStage3Bio) {
         this.stage3Bio = newStage3Bio;
     }
-
-    public String getCard() {
-        return card;
-    }
-
-    public void updateCard(String cardInfoJson) {
-        this.card = cardInfoJson;
-    }
-    // public void applyOnboarding(Set<Long> categoryIds, InteractionStyle style,
-    // String bio) {
-    // this.interestCategoryIds.clear();
-    // if (categoryIds != null) {
-    // this.interestCategoryIds.addAll(categoryIds);
-    // }
-    // this.interactionStyle = (style == null) ? InteractionStyle.UNKNOWN : style;
-    // updateBio(bio);
-    // }
 }

--- a/src/main/java/com/peelie/profile/domain/ProfileCommand.java
+++ b/src/main/java/com/peelie/profile/domain/ProfileCommand.java
@@ -20,7 +20,6 @@ public class ProfileCommand {
                     .instagramId(instagramId)
                     .profileImageUrl(imageUrl)
                     .build();
-
         }
     }
 
@@ -34,6 +33,16 @@ public class ProfileCommand {
         private final String stage1Bio;
         private final String stage2Bio;
         private final String stage3Bio;
+    }
 
+    @Getter
+    @Builder
+    public static class ApplyOnboardingResult {
+        private final Card stage1Card;
+        private final Card stage2Card;
+        private final Card stage3Card;
+        private final String stage1Bio;
+        private final String stage2Bio;
+        private final String stage3Bio;
     }
 }

--- a/src/main/java/com/peelie/profile/domain/ProfileInfo.java
+++ b/src/main/java/com/peelie/profile/domain/ProfileInfo.java
@@ -30,18 +30,22 @@ public class ProfileInfo {
 
         this.interactionStyle = profile.getInteractionStyle();
 
-        //TODO: 재현님 카드 기능 완성 후 실제 데이터 반영
         this.card = new Card(
-                new Card.StageInfo("임시 Stage1 Title", "Stage1 Subtitle", "Stage1 Content"),
-                new Card.StageInfo("임시 Stage2 Title", "Stage2 Subtitle", "Stage1 Content"),
-                new Card.StageInfo("임시 Stage3 Title", "Stage3 Subtitle", "Stage1 Content")
+                new Card.StageInfo(profile.getStage1Card().getTitle(),
+                        profile.getStage1Card().getSubtitle(),
+                        profile.getStage1Card().getContent()),
+                new Card.StageInfo(profile.getStage2Card().getTitle(),
+                        profile.getStage2Card().getSubtitle(),
+                        profile.getStage2Card().getContent()),
+                new Card.StageInfo(profile.getStage3Card().getTitle(),
+                        profile.getStage3Card().getSubtitle(),
+                        profile.getStage3Card().getContent())
         );
     }
 
     @Getter
     @AllArgsConstructor
     public static class BioInfo {
-        // TODO: 임시 메시지 나중에 실제 자기소개 메시지 나오면 변경
         public static final String STAGE0_BIO = "자기소개가 없어요 퀴즈를 풀어주세요.";
 
         private final String stage;

--- a/src/main/java/com/peelie/profile/domain/ProfileService.java
+++ b/src/main/java/com/peelie/profile/domain/ProfileService.java
@@ -7,4 +7,5 @@ public interface ProfileService {
     void resetProfileImage(Long userId);
     void updateInteractionStyle(Long userId, String newInteractionStyle);
     ProfileInfo updateMyProfile(Long userId, ProfileCommand.UpdateCommand command);
+    void applyOnboarding(Long userId, ProfileCommand.ApplyOnboardingResult command);
 }

--- a/src/main/java/com/peelie/profile/domain/ProfileServiceImpl.java
+++ b/src/main/java/com/peelie/profile/domain/ProfileServiceImpl.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ProfileServiceImpl implements ProfileService {
@@ -73,5 +75,13 @@ public class ProfileServiceImpl implements ProfileService {
         profile.changeStage3Bio(command.getStage3Bio());
 
         return new ProfileInfo(profile);
+    }
+
+    @Override
+    @Transactional
+    public void applyOnboarding(Long userId, ProfileCommand.ApplyOnboardingResult command) {
+        Profile profile = profileReader.getProfileByUserId(userId);
+        profile.setBios(List.of(command.getStage1Bio(), command.getStage2Bio(), command.getStage3Bio()));
+        profile.setCards(List.of(command.getStage1Card(), command.getStage2Card(), command.getStage3Card()));
     }
 }

--- a/src/main/java/com/peelie/prompt/UserAnswerLoader.java
+++ b/src/main/java/com/peelie/prompt/UserAnswerLoader.java
@@ -12,6 +12,7 @@ import com.peelie.questionnaire.domain.question.QuestionOption;
 import com.peelie.questionnaire.domain.question.QuestionReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -28,6 +29,7 @@ public class UserAnswerLoader {
     private final QuestionReader questionReader;
     private final ProfileReader profileReader;
 
+    @Transactional(readOnly = true)
     public UserAnswer load(Long userId) {
         OnboardingProcess onboardingProcess = onboardingReader.findOnboardingProcessByUserId(userId);
         return buildUserAnswer(userId, onboardingProcess);


### PR DESCRIPTION
# Pull Request

**[작업 내용을 간략히 적어주세요]**
- 카드, 한줄 소개 생성 서비스 비동기 처리
- 생성된 카드와 한 줄 소개 프로필에 반영

## #️⃣ 연관된 이슈

#78

## 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.
- 프로필 엔티티에 카드 정보 필드 추가
- 온보딩에서 설정된 교류 성향 및 카드, 한줄 소개 프로필에 반영하는 로직 추가
- 카드/한줄소개 생성 api 호출 및 프로필에 저장 메서드에 비동기 적용, 컨트롤러는 즉시 '생성중' 메시지를 클라이언트에 리턴
